### PR TITLE
Pick data from older event on coalescing.

### DIFF
--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -114,8 +114,16 @@ RCT_NOT_IMPLEMENTED(-init)
   return YES;
 }
 
-- (id<RCTEvent>)coalesceWithEvent:(id<RCTEvent>)newEvent
+- (RCTScrollEvent *)coalesceWithEvent:(RCTScrollEvent *)newEvent
 {
+  NSArray *updatedChildFrames = [_userData[@"updatedChildFrames"] arrayByAddingObjectsFromArray:newEvent->_userData[@"updatedChildFrames"]];
+
+  if (updatedChildFrames) {
+    NSMutableDictionary *userData = [newEvent->_userData mutableCopy];
+    userData[@"updatedChildFrames"] = updatedChildFrames;
+    newEvent->_userData = userData;
+  }
+  
   return newEvent;
 }
 


### PR DESCRIPTION
The `ScrollView` sends important `updatedChildFrames` data to the `ListView` to be able to implement `onChangeVisibleRows` method. Coalescing operates very strongly on older devices like the iPhone 4s where this data is then lost.

Fixes #1782.
